### PR TITLE
The caching is now moved to splash screen

### DIFF
--- a/src/edu/yalestc/yalepublic/Cache/CalendarCache.java
+++ b/src/edu/yalestc/yalepublic/Cache/CalendarCache.java
@@ -12,6 +12,7 @@ import java.util.Calendar;
 import edu.yalestc.yalepublic.Events.DateFormater;
 import edu.yalestc.yalepublic.Events.EventsParseForDateWithinCategory;
 import edu.yalestc.yalepublic.JSONReader;
+import edu.yalestc.yalepublic.Splash;
 
 /**
  * Created by Stan Swidwinski on 12/15/14.
@@ -77,6 +78,8 @@ public class CalendarCache extends JSONReader {
         if (dialog != null && dialog.isShowing()) {
             dialog.dismiss();
         }
+
+        ((Splash)mActivity).getIcon();
     }
 
     //can be used both to create and updateEvents preferences.
@@ -118,10 +121,6 @@ public class CalendarCache extends JSONReader {
         }
     }
 
-    //NOT TESTED. PLEASE TEST AFTER DEMO SINCE THIS IS NOT TOO IMPORTANT.
-    //maybe instead of doing that just delete the whole database and redownload it? will be slower
-    //but will have all events, even those added at the last moment
-    //Best way out: have Yale Calendar return JSON with a field being "last updated: YYYYMMDD...
     private void updateDatabase(int year, int month) {
         CalendarDatabaseTableHandler eventTable = new CalendarDatabaseTableHandler(mActivity);
         deleteObsolete(year, month, eventTable);

--- a/src/edu/yalestc/yalepublic/MainActivity.java
+++ b/src/edu/yalestc/yalepublic/MainActivity.java
@@ -114,8 +114,6 @@ public class MainActivity extends Activity {
                 break;
         }
 
-        CalendarCache cache = new CalendarCache(this);
-        cache.execute();
         /*Configuration config = getResources().getConfiguration();
         DisplayMetrics dm = getResources().getDisplayMetrics();
         screenWidth = (double)config.screenWidthDp * dm.density;

--- a/src/edu/yalestc/yalepublic/Splash.java
+++ b/src/edu/yalestc/yalepublic/Splash.java
@@ -29,6 +29,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.ExecutionException;
 
+import edu.yalestc.yalepublic.Cache.CalendarCache;
+
 public class Splash extends Activity {
 
     // Splash screen timer
@@ -40,8 +42,11 @@ public class Splash extends Activity {
 
         setContentView(R.layout.splash);
 
+        CalendarCache cache = new CalendarCache(this);
+        cache.execute();
+    }
 
-
+    public void getIcon(){
 
         new Handler().postDelayed(new Runnable() {
 


### PR DESCRIPTION
Moved caching to splash screen. Caching does not time out, but looking for the link does. First caching happens, then the link happens. 