### PR TITLE
Added refresh button for events and changed the rules of recaching

### DIFF
--- a/res/menu/events_display.xml
+++ b/res/menu/events_display.xml
@@ -1,6 +1,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="edu.yalestc.yalepublic.Events.EventsDisplay">
+    <item android:id="@+id/refresh"
+        android:title="Refresh list of events"
+        android:icon="@android:drawable/ic_popup_sync"
+        android:showAsAction="collapseActionView|always"
+        />
     <item android:id="@+id/search"
         android:title="@string/events_search"
         android:icon="@android:drawable/ic_menu_search"

--- a/src/edu/yalestc/yalepublic/Cache/CalendarDatabaseTableHandler.java
+++ b/src/edu/yalestc/yalepublic/Cache/CalendarDatabaseTableHandler.java
@@ -276,4 +276,9 @@ public class CalendarDatabaseTableHandler extends SQLiteOpenHelper {
         db.rawQuery(query, null);
         db.close();
     }
+
+    public void wipeDatabase(){
+        SQLiteDatabase db = this.getWritableDatabase();
+        db.execSQL("delete from " + TABLE_NAME_EVENTS);
+    }
 }

--- a/src/edu/yalestc/yalepublic/Events/EventCategories.java
+++ b/src/edu/yalestc/yalepublic/Events/EventCategories.java
@@ -15,6 +15,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -25,6 +26,7 @@ import android.widget.RelativeLayout;
 import android.widget.SearchView;
 import android.widget.TextView;
 
+import edu.yalestc.yalepublic.Cache.CalendarCache;
 import edu.yalestc.yalepublic.R;
 
 public class EventCategories extends Activity {
@@ -74,6 +76,39 @@ public class EventCategories extends Activity {
         }
     }
 
+        //adds functionality to the refersh button!
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        //need to create locally inheriting class since the original one
+        //is integral with splash screen (for getting the bot-right icon!)
+        class Updater extends CalendarCache {
+            Updater(Activity mActivity) {
+                super(mActivity);
+            }
+
+            @Override
+            protected void onPostExecute(String result) {
+                if (super.dialog != null && super.dialog.isShowing()) {
+                    super.dialog.dismiss();
+                }
+            }
+
+        }
+
+        //add functinoality to the button
+        switch (item.getItemId()) {
+            case R.id.refresh:
+                Updater cache = new Updater(this);
+                //wipe the database and preferences.
+                cache.wipeDatabase();
+                cache.clearPreferences();
+                //download all the events and recreate the db
+                cache.execute();
+                return true;
+        }
+        //bcs you have to
+        return super.onOptionsItemSelected(item);
+    }
 
     static public class PlaceholderFragment extends Fragment {
 

--- a/src/edu/yalestc/yalepublic/Events/EventsDisplay.java
+++ b/src/edu/yalestc/yalepublic/Events/EventsDisplay.java
@@ -6,10 +6,15 @@ import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.app.SearchManager;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.widget.SearchView;
 
+import java.util.concurrent.ExecutionException;
+
+import edu.yalestc.yalepublic.Cache.CalendarCache;
 import edu.yalestc.yalepublic.Events.CalendarView.CalendarFragment;
 import edu.yalestc.yalepublic.Events.ListView.ListFragment;
 import edu.yalestc.yalepublic.JSONReader;
@@ -103,6 +108,45 @@ public class EventsDisplay extends Activity {
         });
         actionBar.addTab(listT);
 
+    }
+
+    //add functionality to the refresh button
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        //locally inheriting class bcs the original one is an integral part
+        //of splash screen (at least getting the icon in bot-right)
+        class Updater extends CalendarCache {
+            //intent to relaunch the activity after getting new data. Easiest for us.
+            Intent mIntent;
+            Updater(Activity mActivity, Intent intent) {
+                super(mActivity);
+                mIntent = intent;
+            }
+
+            @Override
+            protected void onPostExecute(String result) {
+                if (super.dialog != null && super.dialog.isShowing()) {
+                    super.dialog.dismiss();
+                }
+                //restart the activity
+                super.mActivity.finish();
+                startActivity(mIntent);
+            }
+
+        }
+        //add functionality
+        switch (item.getItemId()) {
+            case R.id.refresh:
+                Updater cache = new Updater(this, getIntent());
+                //get rid of old data
+                cache.wipeDatabase();
+                cache.clearPreferences();
+                //get new data
+                cache.execute();
+                return true;
+        }
+        //bcs you have to
+        return super.onOptionsItemSelected(item);
     }
 
    /* private class DayTab extends Fragment {


### PR DESCRIPTION
Changes according to instructions from Jemin:

1) Added refresh button on the menu in all views connected to events. Functionality:
    a) Wipes out database and preferences
    b) Builds new database populated with new data
    c) Relaunch current activity if needed to propagate data in current view (list/calendar views)

2) Changed rules for getting new data by launch
     a) Wipe out database and preferences once a week and download new data
     b) Changed sharedPreferences to allow for checking if there is need to recache (should work, although I can't really test it right now ---> Anyone?)

3) Commented out functions within Cache that we are not using due to changes mentioned above

4) Changed .xml of menu to add the refresh icon

5) Didn't break anything (I hope, I think, or at least I did not notice anything not working (?))